### PR TITLE
Removed SVN-based revision number

### DIFF
--- a/src/gui/MainFrame.cpp
+++ b/src/gui/MainFrame.cpp
@@ -1661,10 +1661,10 @@ void MainFrame::onSetCMapNo( wxCommandEvent& WXUNUSED(event) )
 /**/
 void MainFrame::onAbout( wxCommandEvent& WXUNUSED(event) )
 {
-    wxString rev = _T( "$Revision$" );
+    wxString rev = _T( "ea8312dd52" );
     rev = rev.AfterFirst('$');
     rev = rev.BeforeLast('$');
-    wxString date = _T( "$Date$" );
+    wxString date = _T( "2013-04-15" );
     date = date.AfterFirst( '$' );
     date = date.BeforeLast( '$' );
     (void)wxMessageBox( _T("Fiber Navigator\nAuthors:http://code.google.com/p/fibernavigator/people/list \n\n" )

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -114,7 +114,7 @@ bool MyApp::OnInit( void )
         Logger::getInstance()->print( wxString::Format( wxT( "shader: %s" ), shaderPath.c_str() ), LOGLEVEL_DEBUG );
 
         // Create the main frame window
-        frame = new MainFrame( wxT("Fiber Navigator 1771"), wxPoint( 50, 50 ), wxSize( 800, 600 ) );
+        frame = new MainFrame( wxT("Fiber Navigator"), wxPoint( 50, 50 ), wxSize( 800, 600 ) );
         SceneManager::getInstance()->setMainFrame( frame );
         SceneManager::getInstance()->setTreeCtrl( frame->m_pTreeWidget );
 


### PR DESCRIPTION
Since the program is not hosted on SVN anymore, keeping the SVN based revision number did not make sense. It will be replaced by the id of the commit used for the build in a future version.
