### PR TITLE
Fiber loading fix

### DIFF
--- a/src/dataset/Fibers.cpp
+++ b/src/dataset/Fibers.cpp
@@ -1357,7 +1357,7 @@ bool Fibers::loadDmri( const wxString &filename )
     m_countPoints = 0;
     float back, front;
     stringstream ss;
-    
+
     for( int i = 0; i < m_countLines; i++ )
     {
         res = fscanf( pFile, "%s %s %s", pS1, pS2, pS3 );
@@ -1368,6 +1368,7 @@ bool Fibers::loadDmri( const wxString &filename )
         ss << pS2;
         ss >> front;
         ss.clear();
+        
         int nbpoints = back + front;
 
         if( back != 0 && front != 0 )


### PR DESCRIPTION
This fixes #116 for fiber loading on a french locale system. It also works if I switch to the en_GB locale, so it didn't break anything else. This is actually Gab's quickfix patch, so if you want to add more stringstream magic to make it more robust, feel free to do so. 
