### PR TITLE
Fixed Value bug for datasets other than anatomies 

### DIFF
--- a/src/gui/MainFrame.cpp
+++ b/src/gui/MainFrame.cpp
@@ -1828,10 +1828,6 @@ void MainFrame::updateStatusBar()
 		
 		if( pAnat != NULL )
 		{
-			float voxelX = DatasetManager::getInstance()->getVoxelX();
-			float voxelY = DatasetManager::getInstance()->getVoxelY();
-			float voxelZ = DatasetManager::getInstance()->getVoxelZ();
-
 			// Select in the list
 			int ind = ( m_pXSlider->GetValue()   +
 						m_pYSlider->GetValue()   * pAnat->getColumns() +


### PR DESCRIPTION
@jchoude

Should not crash anymore when loading datasets that are not anatomies. 
dynamic_cast was a succes.
Also fixed small voxel size problem.
