### PR TITLE
Random initialisation of tractography did'nt ensure that backward and forward tracking was done based on the same peak

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,6 +20,7 @@ Tutorials
 New rs-fMRI and real-time fiber tractography tutorials soon available: `Tutorial Page`_.
 New **video tutorials** of the Fibernavigator are available.
 
+- `Optic radiation`_ : Real-time tractography of the optic radiation using HCP data
 - `Scene navigation`_: how to interact with the 3D view, move planes, etc.
 - `Mesh display and interaction`_: how to create and modify the display of meshes.
 - `Drawing tool`_: how to draw on empty or already existing anatomies.
@@ -72,6 +73,5 @@ All issues have been moved to the new `issue tracker`_. New issues will also be 
 .. _Opacity rendering: https://www.youtube.com/watch?v=IzJ537KNpR0
 .. _Image Gallery: http://chamberm.github.io/media.html
 .. _Tutorial Page: http://chamberm.github.io/fibernavigator_single.html
-
-
+.. _Optic radiation: https://www.youtube.com/watch?v=UDFpvyrXNyA
 

--- a/src/dataset/RTTFibers.cpp
+++ b/src/dataset/RTTFibers.cpp
@@ -147,6 +147,8 @@ void RTTFibers::clearFibersRTT()
     m_streamlinesColors.clear();
     m_streamlinesPoints.clear();
 
+    m_storedDir.clear();
+
     if( SceneManager::getInstance()->isUsingVBO() )
     {
         glDeleteBuffers( 2, m_bufferObjectsRTT );
@@ -1500,7 +1502,17 @@ void RTTFibers::performHARDIRTT(Vector seed, int bwdfwd, vector<float>& points, 
         if( withinMapThreshold(sticksNumber, currPosition) && !m_stop && absPeak != 0)
         {
             bool initWithDir = RTTrackingHelper::getInstance()->isInitSeed();
-            sticks = pickDirection(m_pMaximasInfo->getMainDirData()->at(sticksNumber), initWithDir, currPosition); 
+
+            if(bwdfwd != -1)
+            {
+                sticks = pickDirection(m_pMaximasInfo->getMainDirData()->at(sticksNumber), initWithDir, currPosition); 
+                m_storedDir = sticks;
+            }
+            else
+            { 
+                sticks = m_storedDir;
+            }
+
 
             currDirection.x = flippedAxes.x * sticks[0];
             currDirection.y = flippedAxes.y * sticks[1];

--- a/src/dataset/RTTFibers.h
+++ b/src/dataset/RTTFibers.h
@@ -127,6 +127,8 @@ private:
 
     std::vector<float> m_streamlinesPoints; // Points to be rendered Forward
 	std::vector<float> m_streamlinesColors; //Color (local directions)Forward
+
+    std::vector<float> m_storedDir;
     
 
 	float m_alpha;


### PR DESCRIPTION
Ignore the readme.rst (as it is from my master).

This pull request fixed an important bug in real-time hardi tracking:
-Streamlines initiated from a selected peak where not guaranteed to propagate back and forth in the same direction (i.e. the random initialisation for selecting a peaks from all possibilities inside a voxel was done independantly of the direction to propagate.)

Now we make sur that this direction is preserved.

If merged, let's do a November release with .dmg included aswell.

@jchoude 