### PR TITLE
DTI-RTT rendering 

### DIFF
--- a/src/dataset/RTTFibers.cpp
+++ b/src/dataset/RTTFibers.cpp
@@ -1170,9 +1170,10 @@ void RTTFibers::performDTIRTT(Vector seed, int bwdfwd, vector<float>& points, ve
                 points.push_back( currPosition.x );
                 points.push_back( currPosition.y );
                 points.push_back( currPosition.z );
-                color.push_back( currDirection.x );
-                color.push_back( currDirection.y );
-                color.push_back( currDirection.z );
+                color.push_back( std::abs(currDirection.x) );
+                color.push_back( std::abs(currDirection.y) );
+                color.push_back( std::abs(currDirection.z) );
+                color.push_back( 1.0f );
 
                 //Advance
                 currPosition = nextPosition;


### PR DESCRIPTION
fixed dti-rtt color rendering for @mdesco . Problem was related to a bad indexing of the color array since the introduction of an alpha value for hardi-rtt. This is now set to 1 for DTI-rtt.

In short, RTT-color arrays now have 4 alternating elements (i.e. x1,y1,z1,a1, x2,y2,z2,a2, etc).
@jchoude 
