### PR TITLE
Use right parameter in comparison

### DIFF
--- a/src/misc/Fantom/FTensor.icc
+++ b/src/misc/Fantom/FTensor.icc
@@ -139,7 +139,7 @@ inline void FTensor::setOrder( unsigned char ord)
 
 inline void FTensor::resizeTensor (unsigned char dim, unsigned char ord)
 {
-  if ( dimension!=dim || order != order )
+  if ( dimension!=dim || order != ord )
   {
     order = ord;
     dimension = dim;


### PR DESCRIPTION
Avoid the compiler warning: self-comparison always evaluates to false [-Wtautological-compare]
Allow FTensor::resizeTensor to work as expected if the dimension isn't changed, as the typo is only in the comparison.